### PR TITLE
List comprehension example in 1-intro correction

### DIFF
--- a/1-Intro/README.md
+++ b/1-Intro/README.md
@@ -148,7 +148,7 @@ newlist = map(lambda x: x * 2, sample)
 The one liner using list comprehensions (faster in this case):
 http://docs.python.org/tutorial/datastructures.html#list-comprehensions
 ```python
-newlist = [x * 2 for number in sample]
+newlist = [number * 2 for number in sample]
 ```
 
 Now you're probably thinking, when should I use *Map()*, and when should I use a *List Comprehension*?


### PR DESCRIPTION
I'm not a python expert but a starter. I use it at work sometimes for quick scripting. What I mean is that as a newbie I maybe wrong in my observation.

I was checking the 1 - Intro lesson and notice in Readme.md the following code:

``` python
newlist = [x * 2 for number in sample]
```

and I receive the following error:

``` python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'x' is not defined
```

Reading the given documentation at http://docs.python.org/tutorial/datastructures.html#list-comprehensions, I concluded the code should be:

``` python
newlist = [x * 2 for x in sample]
```

or 

``` python
newlist = [number * 2 for number in sample]
```

I have the feeling the latest is way more descriptive, that's why I choose it.
